### PR TITLE
feat : oauth2 추가 및 프로메테우스 트래픽 로컬테스트

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
 	testImplementation("org.springframework.security:spring-security-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	implementation("io.micrometer:micrometer-registry-prometheus")
+	implementation ("org.springframework.boot:spring-boot-starter-oauth2-client")
 }
 
 tasks.withType<Test> {

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,8 +1,8 @@
 global:
-  scrape_interval: 5s  # 5초마다 수집
+  scrape_interval: 5s
 
 scrape_configs:
   - job_name: 'spring-boot-app'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['host.docker.internal:8080']  # Docker 환경에서도 접근 가능하게 설정
+      - targets: ['localhost:8080']

--- a/src/main/java/com/plan/nest/config/SecurityConfig.java
+++ b/src/main/java/com/plan/nest/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -17,21 +18,13 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 public class SecurityConfig {
 
-    @Bean
-    public AuthenticationManager authenticationManager(UserDetailsService userDetailsService, PasswordEncoder passwordEncoder) {
-        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
-        authProvider.setUserDetailsService(userDetailsService);
-        authProvider.setPasswordEncoder(passwordEncoder);
-
-        return new ProviderManager(authProvider);
-    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (테스트용)
+                .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/metric/**","/actuator/prometheus").permitAll() // Prometheus 접근 허용
+                        .requestMatchers("/**").permitAll() // Prometheus 및 메트릭 엔드포인트에 대한 인증 허용
                         .anyRequest().authenticated()
                 )
                 .formLogin(Customizer.withDefaults()) // 기본 로그인 페이지 활성화

--- a/src/main/java/com/plan/nest/controller/MetricsController.java
+++ b/src/main/java/com/plan/nest/controller/MetricsController.java
@@ -1,15 +1,23 @@
 package com.plan.nest.controller;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/metric")
+@RequestMapping("/metrics")
 public class MetricsController {
 
-    @GetMapping("/test")
+    @Autowired
+    private MeterRegistry meterRegistry;
+
+    @GetMapping
     public String metric() {
-        return "Spring Boot Monitoring with Prometheus & Grafana";
+        PrometheusMeterRegistry prometheusRegistry = (PrometheusMeterRegistry) meterRegistry;
+        String prometheusMetrics = prometheusRegistry.scrape();
+        return prometheusMetrics;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,25 @@
+server:
+  port: 8080
+
 spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          naver:
+            client-id:
+            client-secret:
+            redirect-uri:
+            client-name: Naver
+            authorization-grant-type: authorization_code
+            scope:
+              - name
+          provider:
+            naver:
+              authorization_uri: https://nid.naver.com/oauth2.0/authorize
+              token_uri: https://nid.naver.com/oauth2.0/token
+              user-info-uri: https://openapi.naver.com/v1/nid/me
+              user_name_attribute: response
   datasource:
     url: jdbc:postgresql://localhost:5432/plan-nest
     username: postgres
@@ -18,8 +39,11 @@ management:
   endpoints:
     web:
       exposure:
-        include: prometheus, health, info
-  metrics:
-    export:
-      prometheus:
-        enabled: true
+        include: health,info,prometheus
+  endpoint:
+    prometheus:
+      enabled: true
+
+logging:
+  level:
+    org.springframework.boot.actuate: DEBUG


### PR DESCRIPTION
## OAuth2.0 추가
 - Oauth2.0 login api 는 naver만 추가 예정
 - naver 클라이언트 ID 와 시크릿코드 격리 조치 필요함.

## 시행착오
 - 프로메테우스 윈도우 테스트와 docker 내부 localhost 구분이 명확해야 감지가능
